### PR TITLE
lncli: add source and last_hop params to queryroutes

### DIFF
--- a/cmd/commands/cmd_payments.go
+++ b/cmd/commands/cmd_payments.go
@@ -1163,6 +1163,17 @@ var queryRoutesCommand = cli.Command{
 				"to use as the first hop. This flag can be " +
 				"specified multiple times in the same command.",
 		},
+		cli.StringFlag{
+			Name: "source",
+			Usage: "(optional) the 33-byte hex-encoded public key for the " +
+				"payment source. If empty, self is assumed",
+		},
+		cli.StringFlag{
+			Name: "last_hop",
+			Usage: "(optional) the 33-byte hex-encoded public key " +
+				"for the last hop (penultimate node in the path) " +
+				"to route through for this payment",
+		},
 		cli.StringSliceFlag{
 			Name: "ignore_pair",
 			Usage: "ignore directional node pair " +
@@ -1270,6 +1281,7 @@ func queryRoutes(ctx *cli.Context) error {
 
 	req := &lnrpc.QueryRoutesRequest{
 		PubKey:              dest,
+		SourcePubKey:        ctx.String("source"),
 		Amt:                 amt,
 		FeeLimit:            feeLimit,
 		FinalCltvDelta:      int32(ctx.Int("final_cltv_delta")),
@@ -1284,6 +1296,14 @@ func queryRoutes(ctx *cli.Context) error {
 	req.OutgoingChanIds, err = parseChanIDs(outgoingChanIds)
 	if err != nil {
 		return fmt.Errorf("unable to decode outgoing_chan_id: %w", err)
+	}
+
+	if ctx.IsSet("last_hop") {
+		lastHop, err := hex.DecodeString(ctx.String("last_hop"))
+		if err != nil {
+			return fmt.Errorf("invalid last_hop argument: %w", err)
+		}
+		req.LastHopPubkey = lastHop
 	}
 
 	if ctx.IsSet("route_hints") {

--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -149,10 +149,13 @@ circuit. The indices are only available for forwarding events saved after v0.20.
   `--route_hints` flag](https://github.com/lightningnetwork/lnd/pull/9721) to
   support routing through private channels.
 
-
 * The `lncli fwdinghistory` command now supports two new flags:
   [`--incoming_chan_ids` and `--outgoing_chan_ids`](https://github.com/lightningnetwork/lnd/pull/9356).
   These filters allows to query forwarding events for specific channels.
+
+* `lncli queryroutes` now supports two new optional parameters: `--source` to
+  specify the source node for the route and `--last_hop` to specify the
+  penultimate node in the payment path.
 
 # Improvements
 ## Functional Updates
@@ -304,6 +307,7 @@ reader of a payment request.
 * Boris Nagaev
 * Elle Mouton
 * Erick Cestari
+* Feelancer21
 * Funyug
 * Mohamed Awnallah
 * Olaoluwa Osuntokun


### PR DESCRIPTION
Add two new optional parameters to the lncli queryroutes command:
 --source:   Allows specifying the source node for the route query.
 --last_hop: Allows specifying the penultimate node in the payment path.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
